### PR TITLE
Fix getIPC infinite recursion

### DIFF
--- a/src/transports/IPC.js
+++ b/src/transports/IPC.js
@@ -128,7 +128,7 @@ function getIPC(id = 0) {
     const path = getIPCPath(id);
     const onerror = () => {
       if (id < 10)
-        resolve(getIPC(id++));
+        resolve(getIPC(++id));
       reject(new Error('Could not connect!'));
     };
     const sock = net.createConnection(path, () => {

--- a/src/transports/IPC.js
+++ b/src/transports/IPC.js
@@ -128,7 +128,7 @@ function getIPC(id = 0) {
     const path = getIPCPath(id);
     const onerror = () => {
       if (id < 10)
-        resolve(getIPC(++id));
+        resolve(getIPC(id + 1));
       reject(new Error('Could not connect!'));
     };
     const sock = net.createConnection(path, () => {


### PR DESCRIPTION
The use of a postfix `++` operation was causing getIPC to always be recursively called with id = 0, resulting in an infinite recursion (and subsequently CPU & memory spikes). Switched to a prefix operation to fix the issue.

Might be related to #14 as well, but the `RPC_CONNECTION_TIMEOUT` errors are still produced.